### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Flags:
 
 ## Build from source
 ``` sh
-$ cd $GOPATH/src
+$ cd $GOPATH/src/github.com/yogeshsr/
 $ git clone https://github.com/yogeshsr/kafka-protobuf-console-consumer.git
+$ cd kafka-protobuf-console-consumer
 $ glide install
 $ GO111MODULE=on go build -o ./kafka-protobuf-console-consumer main.go
 ```


### PR DESCRIPTION
The current "Build from Source" manual does not work. The problems:
- a directory change instruction to change into the repo directory was missing for 'glide install' to work
- the build line does not work unless the repo is located under github.com/yogeshsr/